### PR TITLE
All the things i had to change

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,20 @@
 
 This workflow creates a Jira issue when a Dependabot pull request is created with a specific label. It will set the summary of the Jira issue to the title of the Dependabot pull request and the description of the issue to the body of the pull request. It accomplishes this by leveraging two Atlassian Github Actions.
 
-- [Jira Create Action v2.0.0](https://github.com/atlassian/gajira-create/tree/v2.0.0)
+- [Jira Create Action v3.0.1](https://github.com/atlassian/gajira-create/tree/v3.0.1)
 
-- [Jira Login Action v2.0.0](https://github.com/atlassian/gajira-login/tree/v2.0.0)
+- [Jira Login Action v3.0.1](https://github.com/atlassian/gajira-login/tree/v3.0.1)
 
 ## Setup
-1. Copy dependabot_jira.yml into .github/workflows folder in your repository
+1. Copy `dependabot_jira.yml` into `.github/workflows` folder in your repository
 2. Set environment variables in your repository. Instructions can be found [here](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets)
+3. IMPORTANT: The Secret for `JIRA_API_TOKEN` must be added as a Dependabot secret, not an Actions secret. (This is very unclear in the documentation)
+4. If you so desire, change the lookup context in lines 11-15 to determine whether the values are lookups from Variables or Dependabot Secrets context.
+
     - Variables for login
       - `JIRA_BASE_URL` - Example: `https://example.atlassian.net`
       - `JIRA_API_TOKEN` - [Token Generation Instructions](https://confluence.atlassian.com/cloud/api-tokens-938839638.html)
       - `JIRA_USER_EMAIL`
     - Variables for issue creation
-      - `JIRA_PROJECT_KEY` - Example: `JIRA`
+      - `JIRA_PROJECT` - Example: `JIRA`
       - `JIRA_ISSUE_TYPE` - Example: `Story`

--- a/dependabot_jira.yml
+++ b/dependabot_jira.yml
@@ -8,20 +8,20 @@ on:
       - master
 
 env:
-  JIRA_BASE_URL: #Jira URL
-  JIRA_USER_EMAIL: #jira user email
+  JIRA_BASE_URL: ${{ vars.JIRA_BASE_URL }}
+  JIRA_USER_EMAIL: ${{ vars.JIRA_USER_EMAIL }}
   JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-  JIRA_PROJECT: #Jira project key
-  JIRA_ISSUE_TYPE: #Jira issue type
+  JIRA_PROJECT: ${{ vars.JIRA_PROJECT_KEY }}
+  JIRA_ISSUE_TYPE: ${{ vars.JIRA_ISSUE_TYPE }}
 
 jobs:
   create_jira:
     name: Dependabot Jira
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.id == 27856297 #id dependabot user
+    if: github.event.pull_request.user.login  == 'dependabot[bot]' # lookup by ID seems not to work
     steps:
     - name: Login to Jira
-      uses: atlassian/gajira-login@v2.0.0
+      uses: atlassian/gajira-login@v3.0.1
       env:
         JIRA_BASE_URL: ${{ env.JIRA_BASE_URL }}
         JIRA_USER_EMAIL: ${{ env.JIRA_USER_EMAIL }}
@@ -29,7 +29,7 @@ jobs:
 
     - name: Create Jira Issue
       id: create
-      uses: atlassian/gajira-create@v2.0.1
+      uses: atlassian/gajira-create@v3.0.1
       with:
         project: ${{ env.JIRA_PROJECT }}
         issuetype: ${{ env.JIRA_ISSUE_TYPE }}


### PR DESCRIPTION
* Bumped the action versions from 2.0.1 to 3.0.1 (after Dependabot itself told me to)
* Added clarity to the documentation about which type of secrets to set
* Updated `JIRA_PROJECT_KEY` to `JIRA_PROJECT` environment variable to make it work. 
* Changed the lookup for the dependabot user to be by name, rather than by ID
